### PR TITLE
chore: drop accidentally committed Zone.Identifier ADS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ prisma/dev.db-journal
 ./claude
 
 certificates
+
+# Windows NTFS alternate data streams (mark-of-the-web, etc.)
+*:Zone.Identifier

--- a/public/seckc_meshtastic_qr_code.png:Zone.Identifier
+++ b/public/seckc_meshtastic_qr_code.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=about:internet


### PR DESCRIPTION
## Summary
- The PNG `public/seckc_meshtastic_qr_code.png` was committed with its NTFS Zone.Identifier alternate data stream tracked as a separate path. Git for Windows refuses to materialize that path on checkout, which corrupts the index — every `git checkout` / `git reset` of an affected branch shows spurious `D <unrelated-file>` entries and `git read-tree` fails outright unless `core.protectNTFS=false`.
- Removes the orphan path from the index and adds `*:Zone.Identifier` to `.gitignore` so this can't sneak back in.

## Test plan
- [ ] After merge, fresh `git clone` on Windows shows no `D <file>` entries in `git status`.
- [ ] `git reset --hard origin/main` succeeds without needing `core.protectNTFS=false`.
- [ ] The actual PNG still renders on `/meshtastic`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)